### PR TITLE
WebClient 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	//webClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/rtsj/sejongPromise/global/webclient/ChromeAgentWebclient.java
+++ b/src/main/java/rtsj/sejongPromise/global/webclient/ChromeAgentWebclient.java
@@ -1,0 +1,12 @@
+package rtsj.sejongPromise.global.webclient;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier("chromeAgentWebClient")
+public @interface ChromeAgentWebclient {
+}

--- a/src/main/java/rtsj/sejongPromise/global/webclient/WebClientConfig.java
+++ b/src/main/java/rtsj/sejongPromise/global/webclient/WebClientConfig.java
@@ -1,0 +1,26 @@
+package rtsj.sejongPromise.global.webclient;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    @Primary
+    public WebClient plainWebClient() {
+        // todo : connection pool 등 세부 값 조정하기.
+        return WebClient.create();
+    }
+
+    @Bean
+    @Qualifier("chromeAgentWebClient")
+    public WebClient chromeAgentWebClient() {
+        return WebClient.builder()
+                .defaultHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36")
+                .build();
+    }
+}


### PR DESCRIPTION
## WebClient
- 외부 요청이 필요한 경우 해당 HTTP Client 모듈을 사용합니다.

## ChromeAgentWebclient
- chromeAgent를 default로 한 요청을 보냅니다.
- 특정 데이터를 크롤링/스크래핑 하는 용도로 사용됩니다.

----


- [ ] RestTemplates VS WebClient 정리
- [ ] 비동기로 활용해보기




참고 : https://docs.spring.io/spring-framework/reference/web/webflux-webclient.html
