### PR TITLE
Feat : 학생정보 크롤링 API

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,5 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value
+lombok.copyableannotations += com.dku.council.global.config.webclient.ChromeAgentWebClient
+lombok.anyConstructor.addConstructorProperties = true
+lombok.Setter.flagUsage = error
+lombok.data.flagUsage = error

--- a/src/main/java/rtsj/sejongPromise/debug/TEST.java
+++ b/src/main/java/rtsj/sejongPromise/debug/TEST.java
@@ -6,7 +6,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import rtsj.sejongPromise.infra.sejong.model.BookInfo;
+import rtsj.sejongPromise.infra.sejong.model.SejongAuth;
+import rtsj.sejongPromise.infra.sejong.model.StudentInfo;
+import rtsj.sejongPromise.infra.sejong.service.SejongAuthenticationService;
 import rtsj.sejongPromise.infra.sejong.service.SejongBookService;
+import rtsj.sejongPromise.infra.sejong.service.SejongStudentService;
 
 import java.util.List;
 
@@ -17,9 +21,18 @@ import java.util.List;
 public class TEST {
 
     private final SejongBookService bookService;
+    private final SejongStudentService studentService;
+    private final SejongAuthenticationService authService;
 
     @GetMapping("/book-info")
     public List<BookInfo> getBookInfo() {
         return bookService.getBookInfo();
+    }
+
+
+    @GetMapping("/student-info")
+    public StudentInfo getStudentInfo(){
+        SejongAuth auth = authService.getSejongAuth("학번", "비번");
+        return studentService.crawlStudentInfo(auth);
     }
 }

--- a/src/main/java/rtsj/sejongPromise/debug/TEST.java
+++ b/src/main/java/rtsj/sejongPromise/debug/TEST.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import rtsj.sejongPromise.infra.sejong.dto.BookInfo;
+import rtsj.sejongPromise.infra.sejong.model.dto.BookInfo;
 import rtsj.sejongPromise.infra.sejong.service.SejongBookService;
 
 import java.util.List;

--- a/src/main/java/rtsj/sejongPromise/debug/TEST.java
+++ b/src/main/java/rtsj/sejongPromise/debug/TEST.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import rtsj.sejongPromise.infra.sejong.model.dto.BookInfo;
+import rtsj.sejongPromise.infra.sejong.model.BookInfo;
 import rtsj.sejongPromise.infra.sejong.service.SejongBookService;
 
 import java.util.List;

--- a/src/main/java/rtsj/sejongPromise/domain/book/model/BookField.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/model/BookField.java
@@ -1,0 +1,40 @@
+package rtsj.sejongPromise.domain.book.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+@Getter
+public enum BookField {
+    W_HISTORY("서양의 역사와 사상", 1000),
+    E_HISTORY("동양의 역사와 사상", 2000),
+    EW_CULTURE("동서양의 문학", 3000),
+    SCIENCE("과학 사상", 4000);
+
+    private final String name;
+    private final Integer code;
+
+    private static final Map<String, BookField> BY_LABEL =
+            Stream.of(values()).collect(Collectors.toMap(BookField::getName, e -> e));
+
+    private static final Map<Integer, BookField> BY_CODE_LABEL =
+            Stream.of(values()).collect(Collectors.toMap(BookField::getCode, e -> e));
+
+    public static BookField of(String name){
+        if(BY_LABEL.get(name) == null){
+            throw new RuntimeException("존재하지 않는 영역 입니다.");
+        }
+        return BY_LABEL.get(name);
+    }
+
+    public static BookField of(Integer code){
+        if(BY_CODE_LABEL.get(code) == null){
+            throw new RuntimeException("존재하지 않는 code 입니다.");
+        }
+        return BY_CODE_LABEL.get(code);
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/model/BookInfo.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/model/BookInfo.java
@@ -1,4 +1,4 @@
-package rtsj.sejongPromise.infra.sejong.model.dto;
+package rtsj.sejongPromise.infra.sejong.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/model/ExamInfo.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/model/ExamInfo.java
@@ -1,0 +1,30 @@
+package rtsj.sejongPromise.infra.sejong.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@RequiredArgsConstructor
+public class ExamInfo {
+    private final String year;
+    private final String semester;
+    private final String field;
+    private final String title;
+    private final boolean isPass;
+    private final boolean isTest;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExamInfo examInfo = (ExamInfo) o;
+        return Objects.equals(field, examInfo.field) && Objects.equals(title, examInfo.title);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, title);
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/model/SejongAuth.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/model/SejongAuth.java
@@ -1,0 +1,22 @@
+package rtsj.sejongPromise.infra.sejong.model;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.function.Consumer;
+
+public class SejongAuth {
+    private final MultiValueMap<String, String> cookies = new LinkedMultiValueMap<>();
+
+    public SejongAuth(MultiValueMap<String, String> cookies){
+        this.cookies.addAll(cookies);
+    }
+
+    /**
+     * cookies(Consumer<>()) method 사용하기 위함.
+     * @return
+     */
+    public Consumer<MultiValueMap<String, String>> authCookies() {
+        return map -> map.addAll(cookies);
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/model/StudentInfo.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/model/StudentInfo.java
@@ -1,0 +1,18 @@
+package rtsj.sejongPromise.infra.sejong.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class StudentInfo {
+    private final String major;
+    private final String studentId;
+    private final String name;
+    private final String semester;
+    private final boolean isPass;
+    private final List<ExamInfo> examInfoList;
+
+}

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/model/dto/BookInfo.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/model/dto/BookInfo.java
@@ -1,4 +1,4 @@
-package rtsj.sejongPromise.infra.sejong.dto;
+package rtsj.sejongPromise.infra.sejong.model.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongAuthenticationService.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongAuthenticationService.java
@@ -1,0 +1,161 @@
+package rtsj.sejongPromise.infra.sejong.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ResponseStatusException;
+import rtsj.sejongPromise.global.webclient.ChromeAgentWebclient;
+import rtsj.sejongPromise.infra.sejong.model.SejongAuth;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class SejongAuthenticationService {
+    private static final Pattern ERROR_ALERT_PATTERN = Pattern.compile("<p\\s*class=\"tc\">\\s*(.*)\\s*</p>");
+    @Value("${sejong.student.login}")
+    private final String LOGIN_URI;
+
+    @ChromeAgentWebclient
+    private final WebClient webClient;
+
+
+    public SejongAuth getSejongAuth(String studentId, String password){
+        String param = makeParam("userId=%s&password=%s&go=", studentId, password);
+        return login(LOGIN_URI, param, "http://classic.sejong.ac.kr", "http://classic.sejong.ac.kr/userLoginPage.do");
+    }
+
+
+    private SejongAuth login(String uri, String param, String origin, String referer) {
+        MultiValueMap<String, String> cookies = new LinkedMultiValueMap<>();
+
+        // 로그인 시도 -> 302 redirect
+        ResponseEntity<String> response = tryLogin(uri, param, origin, referer);
+        HttpHeaders headers = response.getHeaders();
+
+        //Set-Cookie
+        addMappedCookies(cookies, headers);
+
+        return new SejongAuth(cookies);
+    }
+
+    private void addMappedCookies(MultiValueMap<String, String> dest, HttpHeaders src) {
+        List<String> cookieStrings = src.get(HttpHeaders.SET_COOKIE);
+        List<ResponseCookie> cookies = new ArrayList<>();
+        for(String cookieString : cookieStrings){
+            String[] block = cookieString.split(";");
+            String[] cookieData = block[0].split("=");
+            ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(cookieData[0], cookieData[1]);
+            for(int i=1; i<block.length; i++){
+                builder = addCookieProperties(builder, block[i]);
+            }
+
+            cookies.add(builder.build());
+        }
+
+        for(ResponseCookie cookie : cookies){
+            dest.add(cookie.getName(), cookie.getValue());
+        }
+    }
+
+    private ResponseCookie.ResponseCookieBuilder addCookieProperties(ResponseCookie.ResponseCookieBuilder builder, String properties) {
+        String block[] = properties.split("=");
+        if(block.length == 1){
+            String name = block[0].trim();
+            if(name.equalsIgnoreCase("httponly")) {
+                builder.httpOnly(true);
+            }else if(name.equalsIgnoreCase("secure")){
+                builder.secure(true);
+            }
+        }else if(block.length == 2){
+            String name = block[0].trim();
+            String value = block[1].trim();
+            if(name.equalsIgnoreCase("domain")) {
+                builder.domain(value);
+            }else if(name.equalsIgnoreCase("path")){
+                builder.path(value);
+            }else if(name.equalsIgnoreCase("max-age")){
+                builder.maxAge(Long.parseLong(value));
+            }
+        }
+        return builder;
+    }
+
+    private ResponseEntity<String> tryLogin(String uri, String param, String origin, String referer) {
+        ResponseEntity<String> response;
+        try{
+            response = webClient.post()
+                    .uri(uri)
+                    .header("Origin", origin)
+                    .header("Referer", referer)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .bodyValue(param)
+                    .retrieve()
+                    .toEntity(String.class)
+                    .block();
+        }catch (Throwable t){
+            throw new RuntimeException("로그인 시도 중 에러가 발생했습니다.");
+        }
+        validateResponse(response);
+        validateStatusCode(response);
+        return response;
+    }
+
+    private void validateStatusCode(ResponseEntity<String> response) {
+        if(response.getStatusCode().is2xxSuccessful()){
+            throwLoginFailedException(response);
+            return;
+        }
+        if(!response.getStatusCode().is3xxRedirection()){
+            throw new ResponseStatusException(response.getStatusCode());
+        }
+    }
+
+    private void validateResponse(ResponseEntity<String> response) {
+        if(response == null){
+            throw new RuntimeException("응답값 존재하지 않음");
+        }
+    }
+
+    private void throwLoginFailedException(ResponseEntity<String> response) {
+        String responseBody = response.getBody();
+        if(responseBody == null){
+            throw new RuntimeException("에러 응답 존재하지 않음");
+        }
+        String errorMessage = extractErrorMessage(responseBody);
+        if(errorMessage == null){
+            throw new RuntimeException("에러 메시지 존재하지 않음");
+        }
+        throw new RuntimeException(errorMessage);
+    }
+
+    private String extractErrorMessage(String responseBody) {
+        Matcher matcher = ERROR_ALERT_PATTERN.matcher(responseBody);
+        if(matcher.find()){
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+
+    private String makeParam(String format, String... args){
+        String[] encodedParam = new String[args.length];
+        for(int i=0; i<args.length; i++){
+            encodedParam[i] = URLEncoder.encode(args[i], StandardCharsets.UTF_8);
+        }
+        return String.format(format, encodedParam);
+    }
+
+}

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongBookService.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongBookService.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import rtsj.sejongPromise.global.webclient.ChromeAgentWebclient;
-import rtsj.sejongPromise.infra.sejong.model.dto.BookInfo;
+import rtsj.sejongPromise.infra.sejong.model.BookInfo;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongBookService.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongBookService.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import rtsj.sejongPromise.global.webclient.ChromeAgentWebclient;
-import rtsj.sejongPromise.infra.sejong.dto.BookInfo;
+import rtsj.sejongPromise.infra.sejong.model.dto.BookInfo;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongScrapper.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongScrapper.java
@@ -2,6 +2,7 @@ package rtsj.sejongPromise.infra.sejong.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.reactive.function.client.WebClient;
+import rtsj.sejongPromise.infra.sejong.model.SejongAuth;
 
 @RequiredArgsConstructor
 public class SejongScrapper {
@@ -23,6 +24,25 @@ public class SejongScrapper {
                     .block();
         }catch (Throwable t){
             throw new RuntimeException(t);
+        }
+        return result;
+    }
+
+    protected String requestWebInfo(SejongAuth auth, String uri){
+        String result;
+        try{
+            result = webClient.get()
+                    .uri(uri)
+                    .cookies(auth.authCookies())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+        }catch (Throwable t){
+            throw new RuntimeException(t);
+        }
+
+        if(result == null){
+            throw new RuntimeException("응답값이 존재하지 않습니다.");
         }
         return result;
     }

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongScrapper.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongScrapper.java
@@ -8,6 +8,11 @@ public class SejongScrapper {
 
     private final WebClient webClient;
 
+    /**
+     * 인증이 필요하지 않은 요청은 Html 을 반환합니다.
+     * @param uri
+     * @return
+     */
     protected String requestWebInfo(String uri){
         String result;
         try{
@@ -21,4 +26,5 @@ public class SejongScrapper {
         }
         return result;
     }
+
 }

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongStudentService.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongStudentService.java
@@ -5,6 +5,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import rtsj.sejongPromise.domain.book.model.BookField;
 import rtsj.sejongPromise.global.webclient.ChromeAgentWebclient;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Service
 public class SejongStudentService extends SejongScrapper{
     private final String STUDENT_INFO_URI;
 
@@ -26,7 +28,7 @@ public class SejongStudentService extends SejongScrapper{
         this.STUDENT_INFO_URI = studentInfoUri;
     }
 
-    public StudentInfo createStudentInfo(SejongAuth auth){
+    public StudentInfo crawlStudentInfo(SejongAuth auth){
         String html = requestWebInfo(auth, STUDENT_INFO_URI);
         return parseStudentInfo(html);
     }

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongStudentService.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongStudentService.java
@@ -1,0 +1,96 @@
+package rtsj.sejongPromise.infra.sejong.service;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.reactive.function.client.WebClient;
+import rtsj.sejongPromise.domain.book.model.BookField;
+import rtsj.sejongPromise.global.webclient.ChromeAgentWebclient;
+import rtsj.sejongPromise.infra.sejong.model.ExamInfo;
+import rtsj.sejongPromise.infra.sejong.model.SejongAuth;
+import rtsj.sejongPromise.infra.sejong.model.StudentInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SejongStudentService extends SejongScrapper{
+    private final String STUDENT_INFO_URI;
+
+    public SejongStudentService(@ChromeAgentWebclient WebClient webClient,
+                                @Value("${sejong.student.info}") String studentInfoUri) {
+        super(webClient);
+        this.STUDENT_INFO_URI = studentInfoUri;
+    }
+
+    public StudentInfo createStudentInfo(SejongAuth auth){
+        String html = requestWebInfo(auth, STUDENT_INFO_URI);
+        return parseStudentInfo(html);
+    }
+
+    private StudentInfo parseStudentInfo(String html) {
+        List<ExamInfo> examList = new ArrayList<>();
+
+        Document doc = Jsoup.parse(html);
+
+        Elements studentInfo = getStudentInfo(doc);
+        String major = studentInfo.get(0).text();
+        String studentId = studentInfo.get(1).text();
+        String name = studentInfo.get(2).text();
+        String semester = studentInfo.get(5).text();
+        boolean isPass = studentInfo.get(7).text().contains("인증") | studentInfo.get(7).text().contains("대체이수");
+
+        Elements examInfoList = getExamInfo(doc);
+        addExamInfo(examList, examInfoList);
+        examList= examList.stream().distinct().collect(Collectors.toList());
+
+        return new StudentInfo(major, studentId, name, semester, isPass, examList);
+    }
+
+    private void addExamInfo(List<ExamInfo> examList, Elements examInfoList) {
+        for(Element element : examInfoList){
+            //filtering -> 도서 인증 영역 텍스트를 가지고 있는 Element.
+            List<String> fields = Stream.of(BookField.values()).map(BookField::getName).collect(Collectors.toList());
+
+            for(String field : fields){
+                Elements elementsContainingText = element.getElementsContainingText(field);
+
+                if(elementsContainingText.hasText()){
+                    Elements examInfo = elementsContainingText.select("td");
+                    if(examInfo.text().contains("미응시") || examInfo.text().contains("미이수")){
+                        continue;
+                    }
+                    String[] yearAndSemester = examInfo.get(0).text().split(" ");
+                    String examYear = yearAndSemester[0].substring(0, 4);
+                    String examSemester = yearAndSemester[1];
+                    String title;
+                    boolean isTest;
+                    if(examInfo.get(1).text().equals(field)) {
+                        title = examInfo.get(2).text();
+                        isTest = true;
+                    }else{
+                        title = examInfo.get(3).text();
+                        isTest = false;
+                    }
+                    //no-pass 불합격인 경우.
+                    boolean examPass = !examInfo.select("span.no-pass").hasText();
+
+                    ExamInfo exam = new ExamInfo(examYear, examSemester, field, title, examPass, isTest);
+                    examList.add(exam);
+                }
+            }
+        }
+    }
+
+    private Elements getStudentInfo(Document doc) {
+        return doc.select("div.content-section ul.tblA dd");
+    }
+
+    private Elements getExamInfo(Document doc) {
+        return doc.select("div.content-section div.table_group tbody tr");
+    }
+
+}


### PR DESCRIPTION
## 대양휴머니티 칼리지 인증
- 사용자 정보 인증은 대양휴머니티의 **학번/비번** 으로 확인합니다.
- 인증이 완료되면 **SejongAuth** 객체를 반환합니다. 해당 객체에는 Cookie에 저장된 데이터가 들어가 있습니다.

## @Value
- 생성자 자동 주입 @RequiredArgsConstructor 를 통해 외부 변수를 받아오기 위하여 lombok.config 파일을 수정하였습니다.

---
<img width="979" alt="image" src="https://github.com/SejongUniv-Promise/back/assets/78069223/a23f0891-9973-4854-b15c-085d199d38ea">

----