### PR TITLE
Redis 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// json
+	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/rtsj/sejongPromise/SejongPromiseApplication.java
+++ b/src/main/java/rtsj/sejongPromise/SejongPromiseApplication.java
@@ -2,8 +2,12 @@ package rtsj.sejongPromise;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
+@EnableJpaAuditing
 public class SejongPromiseApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/rtsj/sejongPromise/debug/TEST.java
+++ b/src/main/java/rtsj/sejongPromise/debug/TEST.java
@@ -1,10 +1,16 @@
 package rtsj.sejongPromise.debug;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import rtsj.sejongPromise.domain.book.model.dto.BookDto;
+import rtsj.sejongPromise.domain.book.service.BookService;
+import rtsj.sejongPromise.global.config.redis.RedisKeys;
 import rtsj.sejongPromise.infra.sejong.model.BookInfo;
 import rtsj.sejongPromise.infra.sejong.model.SejongAuth;
 import rtsj.sejongPromise.infra.sejong.model.StudentInfo;
@@ -12,7 +18,9 @@ import rtsj.sejongPromise.infra.sejong.service.SejongAuthenticationService;
 import rtsj.sejongPromise.infra.sejong.service.SejongBookService;
 import rtsj.sejongPromise.infra.sejong.service.SejongStudentService;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.OptionalInt;
 
 @RestController
 @RequestMapping("/test")
@@ -20,19 +28,30 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TEST {
 
-    private final SejongBookService bookService;
+    private final SejongBookService sejongBookService;
+    private final BookService bookService;
     private final SejongStudentService studentService;
     private final SejongAuthenticationService authService;
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
 
     @GetMapping("/book-info")
     public List<BookInfo> getBookInfo() {
-        return bookService.getBookInfo();
+
+        return sejongBookService.getBookInfo();
     }
 
+    @GetMapping("/redis/book-info")
+    public List<BookDto> getBookInfoDto() {
+        List<BookDto> list = bookService.list();
+        return list;
+    }
 
     @GetMapping("/student-info")
-    public StudentInfo getStudentInfo(){
+    public StudentInfo getStudentInfo() throws JsonProcessingException {
         SejongAuth auth = authService.getSejongAuth("학번", "비번");
-        return studentService.crawlStudentInfo(auth);
+        StudentInfo studentInfo = studentService.crawlStudentInfo(auth);
+        return studentInfo;
     }
+
 }

--- a/src/main/java/rtsj/sejongPromise/domain/book/controller/BookController.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/controller/BookController.java
@@ -1,0 +1,26 @@
+package rtsj.sejongPromise.domain.book.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import rtsj.sejongPromise.domain.book.model.dto.BookDto;
+import rtsj.sejongPromise.domain.book.service.BookService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/book")
+@RequiredArgsConstructor
+public class BookController {
+    private final BookService service;
+
+    @GetMapping
+    public List<BookDto> list(@RequestParam(required = false) String field,
+                              @RequestParam(required = false) String keyword){
+        return service.list(field, keyword);
+    }
+
+    @GetMapping("/{bookId}")
+    public BookDto findOne(@PathVariable Long bookId){
+        return service.findOne(bookId);
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/model/Book.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/model/Book.java
@@ -1,0 +1,57 @@
+package rtsj.sejongPromise.domain.book.model;
+
+import lombok.*;
+import org.hibernate.annotations.Where;
+import rtsj.sejongPromise.domain.book.model.field.BookField;
+import rtsj.sejongPromise.domain.book.model.field.BookStatus;
+import rtsj.sejongPromise.global.model.BaseEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "status = 'ACTIVE'")
+public class Book extends BaseEntity {
+    @Id @GeneratedValue
+    @Column(name = "book_id")
+    private Long id;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private BookField field;
+
+    private String writer;
+
+    private String com;
+
+    private String imageUrl;
+
+    private Long code;
+
+    @Enumerated(EnumType.STRING)
+    private BookStatus status;
+
+    @Builder
+    private Book(@NonNull String title,
+                 @NonNull BookField field,
+                 @NonNull String writer,
+                 @NonNull String com,
+                 @NonNull String imageUrl){
+        this.title = title;
+        this.field = field;
+        this.writer = writer;
+        this.com = com;
+        this.imageUrl = imageUrl;
+        this.status = BookStatus.ACTIVE;
+    }
+
+    public void deprecated() {
+        this.status = BookStatus.DEPRECATED;
+    }
+
+    public void updateCode(Long code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/model/dto/BookDto.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/model/dto/BookDto.java
@@ -1,0 +1,27 @@
+package rtsj.sejongPromise.domain.book.model.dto;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import rtsj.sejongPromise.domain.book.model.Book;
+
+@Getter
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class BookDto {
+    private final Long bookId;
+    private final String title;
+    private final String field;
+    private final String writer;
+    private final String com;
+    private final String imageUrl;
+
+    public BookDto(Book book){
+        this.bookId = book.getId();
+        this.title = book.getTitle();
+        this.field = book.getField().getName();
+        this.writer = book.getWriter();
+        this.com = book.getCom();
+        this.imageUrl = book.getImageUrl();
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/model/dto/BookDto.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/model/dto/BookDto.java
@@ -15,6 +15,7 @@ public class BookDto {
     private final String writer;
     private final String com;
     private final String imageUrl;
+    private final Long code;
 
     public BookDto(Book book){
         this.bookId = book.getId();
@@ -23,5 +24,6 @@ public class BookDto {
         this.writer = book.getWriter();
         this.com = book.getCom();
         this.imageUrl = book.getImageUrl();
+        this.code = book.getCode();
     }
 }

--- a/src/main/java/rtsj/sejongPromise/domain/book/model/field/BookField.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/model/field/BookField.java
@@ -1,4 +1,4 @@
-package rtsj.sejongPromise.domain.book.model;
+package rtsj.sejongPromise.domain.book.model.field;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/rtsj/sejongPromise/domain/book/model/field/BookStatus.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/model/field/BookStatus.java
@@ -1,0 +1,9 @@
+package rtsj.sejongPromise.domain.book.model.field;
+
+import lombok.Getter;
+
+@Getter
+public enum BookStatus {
+    ACTIVE,
+    DEPRECATED
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/repository/BookMemoryRepository.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/repository/BookMemoryRepository.java
@@ -1,0 +1,21 @@
+package rtsj.sejongPromise.domain.book.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import rtsj.sejongPromise.domain.book.model.Book;
+import rtsj.sejongPromise.domain.book.model.dto.BookDto;
+import rtsj.sejongPromise.domain.book.model.field.BookStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BookMemoryRepository {
+
+    List<BookDto> findAll();
+    Optional<BookDto> findById(Long id);
+
+    void flushAll();
+
+    BookDto save(Book book);
+
+    List<BookDto> saveAll(List<Book> bookList);
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/repository/BookPersistenceRepository.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/repository/BookPersistenceRepository.java
@@ -1,0 +1,14 @@
+package rtsj.sejongPromise.domain.book.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import rtsj.sejongPromise.domain.book.model.Book;
+import rtsj.sejongPromise.domain.book.model.field.BookField;
+
+import java.util.List;
+
+
+public interface BookPersistenceRepository extends JpaRepository<Book, Long>, JpaSpecificationExecutor<Book> {
+
+    List<Book> findAllByField(BookField of);
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/repository/impl/BookRedisRepository.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/repository/impl/BookRedisRepository.java
@@ -1,0 +1,84 @@
+package rtsj.sejongPromise.domain.book.repository.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+import rtsj.sejongPromise.domain.book.model.Book;
+import rtsj.sejongPromise.domain.book.model.dto.BookDto;
+import rtsj.sejongPromise.domain.book.model.field.BookStatus;
+import rtsj.sejongPromise.domain.book.repository.BookMemoryRepository;
+import rtsj.sejongPromise.global.config.redis.RedisKeys;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class BookRedisRepository implements BookMemoryRepository {
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    @Override
+    public List<BookDto> findAll() {
+        List<BookDto> ret = new ArrayList<>();
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(RedisKeys.BOOK_INFO_KEY);
+        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
+            try {
+                ret.add(objectMapper.readValue((String) entry.getValue(), BookDto.class));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    public Optional<BookDto> findById(Long id)  {
+        Object value = redisTemplate.opsForHash().get(RedisKeys.BOOK_INFO_KEY, id.toString());
+        if(value == null){
+            return Optional.empty();
+        }
+        try {
+            BookDto bookDto = objectMapper.readValue((String) value, BookDto.class);
+            return Optional.of(bookDto);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void flushAll() {
+        redisTemplate.delete(RedisKeys.BOOK_INFO_KEY);
+    }
+
+    @Override
+    public BookDto save(Book book) {
+        BookDto bookDto = new BookDto(book);
+        String value;
+        try {
+            value = objectMapper.writeValueAsString(bookDto);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        redisTemplate.opsForHash().put(RedisKeys.BOOK_INFO_KEY, bookDto.getBookId().toString(), value);
+        return bookDto;
+    }
+
+    @Override
+    public List<BookDto> saveAll(List<Book> bookList) {
+        List<BookDto> list = bookList.stream()
+                .map(BookDto::new)
+                .collect(Collectors.toList());
+        Map<String, String> map = new HashMap<>();
+        for(BookDto dto : list) {
+            try {
+                map.put(dto.getBookId().toString(), objectMapper.writeValueAsString(dto));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        redisTemplate.opsForHash().putAll(RedisKeys.BOOK_INFO_KEY, map);
+        return list;
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/repository/spec/BookSpec.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/repository/spec/BookSpec.java
@@ -1,0 +1,25 @@
+package rtsj.sejongPromise.domain.book.repository.spec;
+
+import org.springframework.data.jpa.domain.Specification;
+import rtsj.sejongPromise.domain.book.model.Book;
+import rtsj.sejongPromise.domain.book.model.field.BookField;
+
+public class BookSpec {
+    public static Specification<Book> withKeyword(String keyword) {
+        if (keyword == null) {
+            return Specification.where(null);
+        }
+
+        String pattern = "%" + keyword + "%";
+        return (root, query, builder) ->
+                builder.like(root.get("title"), pattern);
+    }
+
+    public static Specification<Book> withField(String field) {
+        if (field == null) {
+            return Specification.where(null);
+        }
+        return (root, query, builder) ->
+                builder.equal(root.get("field"), BookField.of(field));
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/scheduler/BookScheduler.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/scheduler/BookScheduler.java
@@ -1,0 +1,25 @@
+package rtsj.sejongPromise.domain.book.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import rtsj.sejongPromise.domain.book.service.BookService;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@RequiredArgsConstructor
+public class BookScheduler {
+    private final BookService bookService;
+
+    @Scheduled(cron = "${book.update-time}")
+    public void updateBookList(){
+        bookService.updateList();
+    }
+
+    @PostConstruct
+    public void init(){
+        bookService.updateList();
+    }
+
+}

--- a/src/main/java/rtsj/sejongPromise/domain/book/service/BookService.java
+++ b/src/main/java/rtsj/sejongPromise/domain/book/service/BookService.java
@@ -1,0 +1,89 @@
+package rtsj.sejongPromise.domain.book.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rtsj.sejongPromise.domain.book.model.Book;
+import rtsj.sejongPromise.domain.book.model.dto.BookDto;
+import rtsj.sejongPromise.domain.book.model.field.BookField;
+import rtsj.sejongPromise.domain.book.repository.BookMemoryRepository;
+import rtsj.sejongPromise.domain.book.repository.BookPersistenceRepository;
+import rtsj.sejongPromise.domain.book.repository.spec.BookSpec;
+import rtsj.sejongPromise.infra.sejong.model.BookInfo;
+import rtsj.sejongPromise.infra.sejong.service.SejongBookService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BookService {
+
+    private final BookMemoryRepository memoryRepository;
+    private final BookPersistenceRepository persistenceRepository;
+    private final SejongBookService sejongBookService;
+
+
+    @Transactional
+    public void updateList(){
+        memoryRepository.flushAll();
+
+        List<Book> bookList = persistenceRepository.findAll();
+        List<String> alreadyTitleList = bookList.stream().map(Book::getTitle).collect(Collectors.toList());
+        List<BookInfo> bookInfoList = sejongBookService.getBookInfo();
+        List<String> updateTitleList = bookInfoList.stream().map(BookInfo::getTitle).collect(Collectors.toList());
+        //#1 기존에 있던 책이 사라진 경우
+        bookList.forEach(book -> {
+            if(!updateTitleList.contains(book.getTitle())){
+                book.deprecated();
+            }
+        });
+        // #2 새로운 책이 생긴 경우
+        bookInfoList.forEach(book -> {
+            if (!alreadyTitleList.contains(book)) {
+                Book newBook = Book.builder()
+                        .title(book.getTitle())
+                        .field(BookField.of(book.getSection()))
+                        .writer(book.getWriter())
+                        .com(book.getCom())
+                        .imageUrl(book.getImageUrl())
+                        .build();
+                persistenceRepository.save(newBook);
+            }
+        });
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookDto> list(){
+        List<BookDto> bookDtoList = memoryRepository.findAll();
+        if(!bookDtoList.isEmpty()){
+            return bookDtoList;
+        }
+        List<Book> bookList = persistenceRepository.findAll();
+        return memoryRepository.saveAll(bookList);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookDto> list(String field, String keyword){
+        if(field == null && keyword == null) return list();
+        Specification<Book> spec = BookSpec.withField(field).and(BookSpec.withKeyword(keyword));
+        return persistenceRepository.findAll(spec).stream()
+                .map(BookDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public BookDto findOne(Long bookId){
+        return memoryRepository.findById(bookId)
+                .orElseGet(() -> {
+                    Book book = persistenceRepository.findById(bookId).orElseThrow(RuntimeException::new);
+                    return memoryRepository.save(book);
+                });
+    }
+
+
+}

--- a/src/main/java/rtsj/sejongPromise/global/config/redis/RedisConfig.java
+++ b/src/main/java/rtsj/sejongPromise/global/config/redis/RedisConfig.java
@@ -1,0 +1,33 @@
+package rtsj.sejongPromise.global.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private final String host;
+
+    @Value("${spring.redis.port}")
+    private final int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory(){
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+        lettuceConnectionFactory.afterPropertiesSet();
+
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/rtsj/sejongPromise/global/config/redis/RedisKeys.java
+++ b/src/main/java/rtsj/sejongPromise/global/config/redis/RedisKeys.java
@@ -1,0 +1,6 @@
+package rtsj.sejongPromise.global.config.redis;
+
+public class RedisKeys {
+    public static final String USER_INFO_KEY = "userinfo";
+    public static final String BOOK_INFO_KEY = "bookinfo";
+}

--- a/src/main/java/rtsj/sejongPromise/global/config/security/SecurityConfig.java
+++ b/src/main/java/rtsj/sejongPromise/global/config/security/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private static final String[] PUBLIC_URI = {
-            "/swagger-ui/**", "/api-docs/**", "/test/**"
+            "/swagger-ui/**", "/api-docs/**", "/test/**","/h2-console/**"
     };
 
     @Bean
@@ -29,6 +29,8 @@ public class SecurityConfig {
                 .formLogin().disable()
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .headers().frameOptions().disable()
                 .and()
                 .authorizeRequests()
                 .antMatchers(PUBLIC_URI).permitAll()

--- a/src/main/java/rtsj/sejongPromise/global/model/BaseEntity.java
+++ b/src/main/java/rtsj/sejongPromise/global/model/BaseEntity.java
@@ -1,0 +1,23 @@
+package rtsj.sejongPromise.global.model;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime create_at;
+
+    @LastModifiedDate
+    private LocalDateTime update_at;
+}

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/model/BookCodeInfo.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/model/BookCodeInfo.java
@@ -1,0 +1,12 @@
+package rtsj.sejongPromise.infra.sejong.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BookCodeInfo {
+    private final String title;
+    private final Long code;
+}
+

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongBookService.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongBookService.java
@@ -1,5 +1,9 @@
 package rtsj.sejongPromise.infra.sejong.service;
 
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
@@ -7,26 +11,30 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import rtsj.sejongPromise.global.webclient.ChromeAgentWebclient;
+import rtsj.sejongPromise.infra.sejong.model.BookCodeInfo;
 import rtsj.sejongPromise.infra.sejong.model.BookInfo;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 public class SejongBookService extends SejongScrapper{
     private final String BOOK_INFO_URI;
+    private final String BOOK_CODE_URI;
     private final String BASE_URL = "https://classic.sejong.ac.kr";
 
     public SejongBookService(@ChromeAgentWebclient WebClient webClient,
-                             @Value("${sejong.book.info}") String bookInfoUri) {
+                             @Value("${sejong.book.info}") String bookInfoUri,
+                             @Value("${sejong.book.code}") String bookCodeUri) {
         super(webClient);
         this.BOOK_INFO_URI = bookInfoUri;
+        this.BOOK_CODE_URI = bookCodeUri;
     }
 
     public List<BookInfo> getBookInfo(){
         String html = requestWebInfo(BOOK_INFO_URI);
         return parseBookInfo(html);
-
     }
 
     /**
@@ -58,5 +66,30 @@ public class SejongBookService extends SejongScrapper{
 
         return bookInfoList;
     }
+
+    /**
+     * 책 코드 정보를 가져옵니다.
+     * @param fieldCode
+     * @return
+     */
+    public List<BookCodeInfo> getBookCode(Integer fieldCode){
+        List<BookCodeInfo> bookCodeInfoList = new ArrayList<>();
+        try{
+            Document doc = Jsoup.connect(String.format(BOOK_CODE_URI, fieldCode.toString())).ignoreContentType(true).get();
+            JSONParser parser = new JSONParser();
+            Object obj = parser.parse(doc.text());
+            JSONObject json = (JSONObject) obj;
+            JSONArray resultArr = (JSONArray) json.get("results");
+            for (Object o : resultArr) {
+                JSONObject bookObj = (JSONObject) o;
+                BookCodeInfo bookCodeInfo = new BookCodeInfo((String) bookObj.get("bkName"), (Long) bookObj.get("bkCode"));
+                bookCodeInfoList.add(bookCodeInfo);
+            }
+        } catch (IOException | ParseException e ) {
+            throw new RuntimeException("책 코드 정보를 가져올 수 없습니다.");
+        }
+        return bookCodeInfoList;
+    }
+
 
 }

--- a/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongStudentService.java
+++ b/src/main/java/rtsj/sejongPromise/infra/sejong/service/SejongStudentService.java
@@ -7,7 +7,7 @@ import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import rtsj.sejongPromise.domain.book.model.BookField;
+import rtsj.sejongPromise.domain.book.model.field.BookField;
 import rtsj.sejongPromise.global.webclient.ChromeAgentWebclient;
 import rtsj.sejongPromise.infra.sejong.model.ExamInfo;
 import rtsj.sejongPromise.infra.sejong.model.SejongAuth;


### PR DESCRIPTION
## Redis 도입
세종대학교 도서 목록 데이터는 주기적으로 크롤링하는 데이터이므로, 데이터가 장기간 변하지 않기에 캐싱해서 쓰기 유용합니다.
따라서, 도서 목록을 Redis 저장소에 **bookinfo** 를 **Key**로 하여, field:<bookId>, value:<BookDto> 로 저장합니다.

**redis 자료구조를 효율적으로 활용하기 위해서는 key값에 대한 접근많이 가능하므로, 동적쿼리 생성에는 persistenceRepository를 사용합니다.**

**bookInfo 를 key로 저장**
<img width="170" alt="image" src="https://github.com/SejongUniv-Promise/back/assets/78069223/276e655e-97db-4781-ae11-97718ca081a7">

**bookInfo Field List**
<img width="220" alt="image" src="https://github.com/SejongUniv-Promise/back/assets/78069223/74621405-ca54-4b97-bc7a-c092775ade06">

**Value**
<img width="569" alt="image" src="https://github.com/SejongUniv-Promise/back/assets/78069223/12a23921-8a39-4f59-a0c2-3f2b60475994">

## Memory DB & Persistence DB
**redis에서 조회 가능한 데이터는 우선적으로 MemoryDB를 조회합니다. 만약, MemoryDB에 데이터가 적재되어 있지 않을 경우, Persistence DB에서 데이터를 Memory DB에 저장한 뒤 반환합니다.**
